### PR TITLE
Added registered email confirmation

### DIFF
--- a/app/models/buyer.rb
+++ b/app/models/buyer.rb
@@ -1,6 +1,6 @@
 class Buyer < ApplicationRecord
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 end

--- a/app/views/buyers/shared/_links.html.erb
+++ b/app/views/buyers/shared/_links.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to "Didn't receive confirmation instructions?", new_buyer_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
 
@@ -74,5 +74,20 @@ Rails.application.configure do
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
+  config.action_mailer.perform_deliveries = true
+
+  config.action_mailer.default :charset => "utf-8"
+ config.action_mailer.default_url_options = { :host => 'localhost:3000' }
+config.action_mailer.delivery_method = :smtp
+# config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
+
+config.action_mailer.smtp_settings = {
+  address:              'smtp.gmail.com',
+  port:                 587,
+  user_name:            'riojan.sevilla@gmail.com',
+  password:             'P@$$W0rD',
+  authentication:       'plain',
+  enable_starttls_auto: true }
+
+
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'riojan.sevilla@gmail.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/db/migrate/20210302220824_add_new_confirmable_to_buyers.rb
+++ b/db/migrate/20210302220824_add_new_confirmable_to_buyers.rb
@@ -1,0 +1,7 @@
+class AddNewConfirmableToBuyers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :buyers, :confirmation_token, :string
+    add_column :buyers, :confirmed_at, :datetime
+    add_column :buyers, :confirmation_sent_at, :datetime
+  end
+end

--- a/db/migrate/20210303112351_add_unconfirmed_email_to_buyers.rb
+++ b/db/migrate/20210303112351_add_unconfirmed_email_to_buyers.rb
@@ -1,0 +1,5 @@
+class AddUnconfirmedEmailToBuyers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :buyers, :unconfirmed_email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_02_211100) do
+ActiveRecord::Schema.define(version: 2021_03_03_112351) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -48,6 +48,10 @@ ActiveRecord::Schema.define(version: 2021_03_02_211100) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "first_name"
     t.string "last_name"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
     t.index ["email"], name: "index_buyers_on_email", unique: true
     t.index ["reset_password_token"], name: "index_buyers_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
Hi regina, I finished adding the email confirmation when our buyers register. Here are the things I did:

1. Added new migration files so the :confirmable method could work. Just run db:migrate to sync the database

![image](https://user-images.githubusercontent.com/72100067/109823764-ab1e0a80-7c51-11eb-9b67-8b8dd7d93f32.png)

2. installed mailcatcher gem for testing purposes.

3. Fixed the settings on development.rb so we could test the actual email sending.

4. Added `config.mailer_sender = 'riojan.sevilla@gmail.com'` to devise.rb (for some reason ayaw kasi gumana pag wala ito lol)

Try to test on your machine kung nagana.


