### PR TITLE
added request test for broker and buyer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem 'bootsnap', '>= 1.4.4', require: false
 
 gem 'devise'
 
+gem 'rails-controller-testing'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,10 @@ GEM
       bundler (>= 1.15.0)
       railties (= 6.1.3)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.5)
+      actionpack (>= 5.0.1.rc1)
+      actionview (>= 5.0.1.rc1)
+      activesupport (>= 5.0.1.rc1)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -256,6 +260,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.3)
+  rails-controller-testing
   rspec-rails (~> 4.0.2)
   sass-rails (>= 6)
   selenium-webdriver

--- a/spec/requests/brokers_spec.rb
+++ b/spec/requests/brokers_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe "Brokers", type: :request do
-  describe "GET /brokers" do
-    it "works! (now write some real specs)" do
-      get brokers_path
-      expect(response).to have_http_status(200)
+  let(:broker) {create(:broker)}
+
+  describe "GET /brokers/:id" do
+    it "gets Broker show method" do
+      get broker_path(broker)
+      expect(response).to render_template(:show)
     end
   end
 end

--- a/spec/requests/buyers_spec.rb
+++ b/spec/requests/buyers_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe "Buyers", type: :request do
+  let(:buyer) {create(:buyer)}
+
+  describe "GET /buyers/:id" do
+    it "gets Buyers show method" do
+      get buyer_path(buyer)
+      expect(response).to render_template(:show)
+    end
+  end
+end


### PR DESCRIPTION
Request testing is required so I added request test for broker and buyer:
- [x] Added gem 'rails-controller-testing'
- [x] Added request test for broker
- [x] Added request test for buyer

Note: This is is subject to change in the future since we don't have the transaction and stocks functions yet.