### PR TITLE
added admin request rspec

### DIFF
--- a/spec/factories/admins.rb
+++ b/spec/factories/admins.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :admin do
+    email { "admin@gmail.com" }
+    password {"123456"}
+    password_confirmation {"123456"}
+  end
+end

--- a/spec/factories/brokers.rb
+++ b/spec/factories/brokers.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     email { Faker::Internet.email }
     password {"helloworld"}
     password_confirmation {"helloworld"}
+    approved {false}
   end
 end

--- a/spec/mailers/broker_mailer_spec.rb
+++ b/spec/mailers/broker_mailer_spec.rb
@@ -1,5 +1,33 @@
 require "rails_helper"
 
 RSpec.describe BrokerMailer, type: :mailer do
-  pending "add some examples to (or delete) #{__FILE__}"
+  let(:broker) {create(:broker)}
+
+  describe "1. new broker pending approval" do
+    let(:mail) {BrokerMailer.new_broker_pending(broker.email)}
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Account pending for approval")
+      expect(mail.to).to eq([broker.email])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content("registered")
+    end
+  end
+
+  describe "2. new broker approved" do
+    let(:mail) {BrokerMailer.new_broker_approved(broker.email)}
+
+    it "renders the headers" do
+      expect(mail.subject).to eq("Account approved")
+      expect(mail.to).to eq([broker.email])
+      expect(mail.from).to eq(["from@example.com"])
+    end
+
+    it "renders the body" do
+      expect(mail.body.encoded).to have_content("approved")
+    end
+  end
 end

--- a/spec/mailers/previews/broker_mailer_preview.rb
+++ b/spec/mailers/previews/broker_mailer_preview.rb
@@ -1,4 +1,12 @@
 # Preview all emails at http://localhost:3000/rails/mailers/broker_mailer
 class BrokerMailerPreview < ActionMailer::Preview
+    def new_broker_pending
+        broker = Broker.create(first_name: "John", last_name: "Doe", email: 'to@example.com', password: '123456', password_confirmation: '123456')
+        BrokerMailer.new_broker_pending(broker.email)
+    end
 
+    def new_broker_approved
+        broker = Broker.create(first_name: "John", last_name: "Doe", email: 'to@example.com', password: '123456', password_confirmation: '123456')
+        BrokerMailer.new_broker_approved(broker.email)
+    end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,4 +65,11 @@ RSpec.configure do |config|
 
   #for factory bot
   config.include FactoryBot::Syntax::Methods
+
+  # config.expect_with :rspec do |c|
+  #   c.syntax = :expect
+  # end
+
+   config.include Devise::Test::ControllerHelpers, :type => :controller
+   config.include Warden::Test::Helpers
 end

--- a/spec/requests/admins_spec.rb
+++ b/spec/requests/admins_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe "Admins", type: :request do
   let(:admin) {create(:admin)}
   let(:broker) {create(:broker)}
   let(:buyer) {create(:buyer)}
+  let(:attrs_broker) {attributes_for(:broker)}
+  let(:attrs_buyer) {attributes_for(:buyer)}
   
   before(:each) do
     login_as(admin)
@@ -23,7 +25,7 @@ RSpec.describe "Admins", type: :request do
       expect(response).to render_template(:new_broker)
     end
     it "2. gets admin post broker path" do
-    post create_broker_admin_path, :params => {broker: {first_name: 'Rio', last_name: 'Sevilla', email: 'test@gmail.com', password: 'test123456', password_confirmation: '123456', approved: false}}
+    post create_broker_admin_path, params: { broker: attrs_broker }
     expect(response).to redirect_to admins_path
     end
   end
@@ -40,6 +42,42 @@ RSpec.describe "Admins", type: :request do
       put approve_broker_admin_path(broker)
       expect(response).to redirect_to admins_path
       expect(ActionMailer::Base.deliveries.count).to eq 2
+    end
+  end
+
+  describe "creates a new buyer account" do
+    it "1. gets admin new buyer path" do
+      get new_buyer_admin_path
+      expect(response).to render_template(:new_buyer)
+    end
+
+    it "2. gets admin post buyer path" do
+      post create_buyer_admin_path, params: { buyer: attrs_buyer }
+      expect(response).to redirect_to admins_path
+    end
+  end
+
+  describe "updates a broker account" do
+    it "1. gets admin edit broker path" do
+      get edit_broker_admin_path(broker)
+      expect(response).to render_template(:edit_broker)
+    end
+
+    it "2. gets admin update broker path" do
+      put update_broker_admin_path(broker), params: { broker: attrs_broker }
+      expect(response).to redirect_to admins_path
+    end
+  end
+
+  describe "updates a buyer account" do
+    it "1. gets admin edit buyer path" do
+      get edit_buyer_admin_path(buyer)
+      expect(response).to render_template(:edit_buyer)
+    end
+
+    it "2. gets admin update buyer path" do
+      put update_buyer_admin_path(buyer), params: { buyer: attrs_buyer }
+      expect(response).to redirect_to admins_path
     end
   end
 

--- a/spec/requests/admins_spec.rb
+++ b/spec/requests/admins_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+
+RSpec.describe "Admins", type: :request do
+  let(:admin) {create(:admin)}
+  let(:broker) {create(:broker)}
+  let(:buyer) {create(:buyer)}
+  
+  before(:each) do
+    login_as(admin)
+  end
+
+  describe "GET /admins" do
+    it "1. gets admin index path" do
+      get admins_path
+      expect(response).to render_template(:index)
+    end
+  end
+
+  describe "creates a new broker account" do
+    it "1. gets admin new broker path" do
+      get new_broker_admin_path
+      expect(response).to render_template(:new_broker)
+    end
+    it "2. gets admin post broker path" do
+    post create_broker_admin_path, :params => {broker: {first_name: 'Rio', last_name: 'Sevilla', email: 'test@gmail.com', password: 'test123456', password_confirmation: '123456', approved: false}}
+    expect(response).to redirect_to admins_path
+    end
+  end
+
+  describe "GET /admins/pending/broker" do
+    it "1. gets admin pending broker path" do
+      get pending_broker_signup_admin_path
+      expect(response).to render_template(:pending_broker_signup)
+    end
+  end
+
+  describe "broker approval process" do
+    it "1. sends an email to broker when approved" do
+      put approve_broker_admin_path(broker)
+      expect(response).to redirect_to admins_path
+      expect(ActionMailer::Base.deliveries.count).to eq 2
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+ 
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
Request testing is required so I added request test for admin
- [x] Included Warden config in rails_helper.rb
- [x] admin request test for: index, creating new broker, pending sign up, and approving sign up
- [x]  admin request test for: creating buyer, updating broker/buyer
- [x] mailer test for broker_mailer

Screenshots:
[Screenshot_2021-03-10 console test result]

![image](https://user-images.githubusercontent.com/72100067/110636089-4d477080-81c5-11eb-9034-86143a163f00.png)

**Update:**

![image](https://user-images.githubusercontent.com/70880887/110644367-12920800-81c6-11eb-8f33-aa2e3699a49e.png)

[Screenshot_2021-03-10 console test result for mailer]
![image](https://user-images.githubusercontent.com/70880887/110677234-f8682200-81e5-11eb-8ea3-1a4440f9d409.png)

References:
https://yuta-san.medium.com/a-simple-login-test-with-rspec-devise-factorybot-in-rails-29aeb2ebc4ab
https://relishapp.com/rspec/rspec-rails/docs/mailer-specs
