### PR TITLE
Fix/changed to mailtrap

### DIFF
--- a/app/mailers/broker_mailer.rb
+++ b/app/mailers/broker_mailer.rb
@@ -2,6 +2,8 @@ class BrokerMailer < ApplicationMailer
   default from: 'from@example.com'
   layout 'mailer'
 
+  include Devise::Controllers::UrlHelpers
+
   def new_broker_pending(email)
     @email = email
     mail(to: @email, subject: 'Account pending for approval')

--- a/app/views/brokers/shared/_error_messages.html.erb
+++ b/app/views/brokers/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
+  <div class="text-light" id="error_explanation">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,

--- a/app/views/buyers/shared/_error_messages.html.erb
+++ b/app/views/buyers/shared/_error_messages.html.erb
@@ -1,5 +1,5 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation">
+  <div class="text-light" id="error_explanation">
     <h2>
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -82,11 +82,20 @@ config.action_mailer.delivery_method = :smtp
 # config.action_mailer.smtp_settings = {:address => "localhost", :port => 1025}
 
 config.action_mailer.smtp_settings = {
-  address:              'smtp.gmail.com',
-  port:                 587,
-  user_name:            Rails.application.credentials.user_name,
-  password:             Rails.application.credentials.password,
-  authentication:       'plain',
-  enable_starttls_auto: true }
+  :user_name => '9ae4ede22e525e',
+  :password => 'd68615c9fe0667',
+  :address => 'smtp.mailtrap.io',
+  :domain => 'smtp.mailtrap.io',
+  :port => '2525',
+  :authentication => :cram_md5
+}
+
+# config.action_mailer.smtp_settings = {
+#   address:              'smtp.gmail.com',
+#   port:                 587,
+#   user_name:            Rails.application.credentials.user_name,
+#   password:             Rails.application.credentials.password,
+#   authentication:       'plain',
+#   enable_starttls_auto: true }
 
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,10 +24,10 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'avionmeetthestockers@gmail.com'
+  config.mailer_sender = 'donotreply@example.com'
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'BrokerMailer'
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'


### PR DESCRIPTION
This PR is for complying with Heroku requirement for deployment.

- [x] changed from gmail to mailtrap

Screenshots:
![Screenshot_2021-03-22 broker pending approval email]
![image](https://user-images.githubusercontent.com/70880887/111974539-8c07ef80-8b10-11eb-8371-f1858d5d2a09.png)

![Screenshot_2021-03-22 broker listed under pending for approval]
![image](https://user-images.githubusercontent.com/70880887/111974312-55ca7000-8b10-11eb-9cfc-3e5c89476089.png)

![Screenshot_2021-03-22 broker account approved email]
![image](https://user-images.githubusercontent.com/70880887/111974602-9e822900-8b10-11eb-923f-29c2109d1b4f.png)

![Screenshot_2021-03-22 broker listed under approved accounts]
![image](https://user-images.githubusercontent.com/70880887/111974350-60850500-8b10-11eb-812c-d6881ce8c4f4.png)

Reference:
https://blog.mailtrap.io/devise-reset-password/